### PR TITLE
fix: types via JSDoc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,4 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm test
+      - run: npm run types

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dist
 
 # Project spesific
 build
+types/**/*.d.ts
+!hubro.d.ts

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+save-exact=true

--- a/fixup.js
+++ b/fixup.js
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Prepend the generated types/main.d.ts with the types that get decorated on
+// the Hubro Fastify server.
+
+let hubro = path.join(process.cwd(), 'types', 'hubro.d.ts');
+let module = path.join(process.cwd(), 'types', 'main.d.ts');
+
+fs.writeFileSync(
+  module,
+  `${fs.readFileSync(hubro, 'utf-8')}
+${fs.readFileSync(module, 'utf-8')}`,
+  'utf-8',
+);

--- a/lib/build/build-entries.js
+++ b/lib/build/build-entries.js
@@ -7,23 +7,25 @@ import { rollup } from 'rollup';
 import { fileURLToPath } from 'node:url';
 
 export default async (logger, config, hierarchy) => {
+  /** @type {import('rollup').RollupOptions} */
   const inputOptions = {
     input: hierarchy.toBundle(),
     plugins: [
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginResolve({ preferBuiltins: true }),
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginCommonjs({ include: /node_modules/ }),
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginReplace({
         'process.env.NODE_ENV': JSON.stringify('production'),
         preventAssignment: true,
       }),
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginTerser({ format: { comments: false } }),
     ],
   };
 
+  /** @type {import('rollup').OutputOptions[]} */
   const outputOptionsList = [
     {
       // preserveModules: true,

--- a/lib/build/build-system.js
+++ b/lib/build/build-system.js
@@ -10,31 +10,32 @@ import { join } from 'node:path';
 // Set root be root folder of the Hubro module because
 // we want to bundle up files in the Hubro module (not
 // in the project using the Hubro module).
-// @ts-ignore
 const root = join(import.meta.dirname, '../../');
 
 export default async (logger, config) => {
+  /** @type {import('rollup').RollupOptions} */
   const inputOptions = {
     input: ['@lit-labs/ssr-client/lit-element-hydrate-support.js'],
     plugins: [
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginResolve({
         preferBuiltins: true,
         rootDir: root,
         browser: true,
       }),
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginCommonjs({ include: /node_modules/ }),
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginReplace({
         'process.env.NODE_ENV': JSON.stringify('production'),
         preventAssignment: true,
       }),
-      // @ts-ignore
+      // @ts-expect-error
       rollupPluginTerser({ format: { comments: false } }),
     ],
   };
 
+  /** @type {import('rollup').OutputOptions[]} */
   const outputOptionsList = [
     {
       // preserveModules: true,

--- a/lib/build/build.js
+++ b/lib/build/build.js
@@ -8,6 +8,7 @@ import Hierarchy from '../common/hierarchy.js';
 export default async (config) => {
   const hierarchy = new Hierarchy({ config });
 
+  // @ts-expect-error
   const logger = pino({
     level: config.logLevel,
     name: config.logName,

--- a/lib/common/config.js
+++ b/lib/common/config.js
@@ -11,11 +11,9 @@ import paths from './config-paths.js';
 
 import { resolveCwd } from './utils.js';
 
-// @ts-ignore
 const pkgJson = fs.readFileSync(path.join(import.meta.dirname, '../../package.json'), 'utf-8');
 const pkg = JSON.parse(pkgJson);
 
-// @ts-ignore
 const pkgDefaults = path.join(import.meta.dirname, '../../defaults');
 
 /**
@@ -108,7 +106,7 @@ export default class Config {
         server(this, entry);
         paths(this, entry);
       });
-    } catch (err) {  // eslint-disable-line
+    } catch {
       // Ignore that file does not exist
     }
 
@@ -266,6 +264,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirSrc(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.src is not relative. Must be relative path.');
@@ -293,6 +294,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirBuild(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.build is not relative. Must be relative path.');
@@ -320,6 +324,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirComponents(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.components is not relative. Must be relative path.');
@@ -347,6 +354,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirLayouts(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.layouts is not relative. Must be relative path.');
@@ -375,6 +385,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirPublic(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.public is not relative. Must be relative path.');
@@ -403,6 +416,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirSystem(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.system is not relative. Must be relative path.');
@@ -429,6 +445,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirPages(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.pages is not relative. Must be relative path.');
@@ -452,6 +471,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirCss(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.css is not relative. Must be relative path.');
@@ -475,6 +497,9 @@ export default class Config {
     return pathToFileURL(joined);
   }
 
+  /**
+   * @param {string} value
+   */
   set dirJs(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for directories.js is not relative. Must be relative path.');
@@ -508,6 +533,9 @@ export default class Config {
     return new URL(this.#urlPathBase, url);
   }
 
+  /**
+   * @param {string} value
+   */
   set urlPathBase(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for paths.base is not relative. Must be relative path.');
@@ -536,6 +564,9 @@ export default class Config {
     return new URL(this.#urlPathPublic, url);
   }
 
+  /**
+   * @param {string} value
+   */
   set urlPathPublic(value) {
     if (path.isAbsolute(value)) {
       throw new Error('Value for paths.public is not relative. Must be relative path.');

--- a/lib/common/hierarchy.js
+++ b/lib/common/hierarchy.js
@@ -22,17 +22,21 @@ export default class HierarchyRoutes {
   /**
    * @param {object} options
    * @param {Config} [options.config]
+   * @param {import('abslog').AbstractLoggerOptions} [options.logger]
    */
   constructor({ config, logger }) {
     this.logger = abslog(logger);
     this.config = config;
 
-    this.routesGlob = new Glob([`**/action.{ts,js}`, `**/route.{ts,js}`, `**/page.{ts,js}`], {
-      withFileTypes: true,
-      posix: true,
-      nodir: true,
-      cwd: this.config.dirPages,
-    });
+    this.routesGlob = new Glob(
+      [`**/action.{ts,js}`, `**/route.{ts,js}`, `**/page.{ts,js}`],
+      /** @type {import('glob').GlobOptionsWithFileTypesTrue} */ ({
+        withFileTypes: true,
+        posix: true,
+        nodir: true,
+        cwd: this.config.dirPages,
+      }),
+    );
 
     this.routes = new Map();
 
@@ -155,7 +159,7 @@ export default class HierarchyRoutes {
         this.middleware = uri;
         this.logger.trace(`Using user defined middleware.js at ${uri.pathname}`);
       }
-    } catch (err) { // eslint-disable-line
+    } catch {
       this.middleware = new URL('./system/middleware.js', this.config.pkgDefaults);
       this.logger.trace(`No user defined middleware.js found. Using system default.`);
     }
@@ -174,7 +178,7 @@ export default class HierarchyRoutes {
         this.document = uri;
         this.logger.trace(`Using user defined document.js at ${uri.pathname}`);
       }
-    } catch (err) { // eslint-disable-line
+    } catch {
       this.document = new URL('./system/document.js', this.config.pkgDefaults);
       this.logger.trace(`No user defined document.js found. Using system default.`);
     }
@@ -193,7 +197,7 @@ export default class HierarchyRoutes {
         this.notFound = uri;
         this.logger.trace(`Using user defined not-found.js at ${uri.pathname}`);
       }
-    } catch (err) { // eslint-disable-line
+    } catch {
       this.notFound = new URL('./system/not-found.js', this.config.pkgDefaults);
       this.logger.trace(`No user defined not-found.js found. Using system default.`);
     }
@@ -212,7 +216,7 @@ export default class HierarchyRoutes {
         this.error = uri;
         this.logger.trace(`Using user defined error.js at ${uri.pathname}`);
       }
-    } catch (err) { // eslint-disable-line
+    } catch {
       this.error = new URL('./system/error.js', this.config.pkgDefaults);
       this.logger.trace(`No user defined error.js found. Using system default.`);
     }

--- a/lib/server/plugins/bundler/bundler.js
+++ b/lib/server/plugins/bundler/bundler.js
@@ -55,7 +55,9 @@ export default fp(
     const moduleCache = new Map();
 
     fastify.addHook('onListen', async () => {
-      const { address, port } = fastify.server.address();
+      const { address, port } = /** @type {{ address: string; family: string; port: number;}} */ (
+        fastify.server.address()
+      );
 
       const components = config.urlPathToJs('/components/').pathname;
       const layouts = config.urlPathToJs('/layouts/').pathname;

--- a/lib/server/plugins/errors/errors.js
+++ b/lib/server/plugins/errors/errors.js
@@ -34,29 +34,36 @@ export default fp(
       throw new httpError.NotFound();
     });
 
-    fastify.setErrorHandler((error, request, reply) => {
-      fastify.log.error(error);
+    fastify.setErrorHandler(
+      /**
+       * @param {import('fastify').FastifyError} error
+       * @param {import('fastify').FastifyRequest} request
+       * @param {import('fastify').FastifyReply & { ssr?: (page: any) => import('@lit-labs/ssr/lib/render-result-readable.js').RenderResultReadable }} reply
+       */
+      (error, request, reply) => {
+        fastify.log.error(error);
 
-      const accept = request.accepts();
-      const status = getStatusCode(error);
+        const accept = request.accepts();
+        const status = getStatusCode(error);
 
-      reply.status(status);
+        reply.status(status);
 
-      if (accept.type('html') && request.method === 'GET') {
-        reply.type('text/html');
-        if (status === 404) {
-          return reply.ssr(pageNotFound);
+        if (accept.type('html') && request.method === 'GET') {
+          reply.type('text/html');
+          if (status === 404) {
+            return reply.ssr(pageNotFound);
+          }
+          return reply.ssr(pageError);
         }
-        return reply.ssr(pageError);
-      }
 
-      if (accept.type('json')) {
-        reply.type('application/json');
-        return reply.send({ error: true, status });
-      }
+        if (accept.type('json')) {
+          reply.type('application/json');
+          return reply.send({ error: true, status });
+        }
 
-      reply.send('Internal server error');
-    });
+        reply.send('Internal server error');
+      },
+    );
   },
   {
     fastify: '4',

--- a/lib/server/plugins/middleware/middleware.js
+++ b/lib/server/plugins/middleware/middleware.js
@@ -29,59 +29,63 @@ export default fp(
     const pub = config.urlPathPublic.pathname;
     const js = config.urlPathToJs().pathname;
 
-    fastify.addHook('preHandler', async (request) => {
-      const route = request.routeOptions.url;
+    fastify.addHook(
+      'preHandler',
+      /** @param {import('fastify').FastifyRequest & { hRequest?: Request; hResponse?: Response; }} request */
+      async (request) => {
+        const route = request.routeOptions.url;
 
-      // Do not run on undefined routes (404s)
-      if (route === undefined) {
-        return;
-      }
+        // Do not run on undefined routes (404s)
+        if (route === undefined) {
+          return;
+        }
 
-      // Do not run on static file routes and development routes
-      if (route.startsWith(pub) || route.startsWith(js)) {
-        return;
-      }
+        // Do not run on static file routes and development routes
+        if (route.startsWith(pub) || route.startsWith(js)) {
+          return;
+        }
 
-      const url = `${request.protocol}://${request.hostname}${request.url}`;
+        const url = `${request.protocol}://${request.hostname}${request.url}`;
 
-      // TODO: Make request.params match router roules
-      // Ex; { '*': 'lit' } -> * is not part of router??
+        // TODO: Make request.params match router roules
+        // Ex; { '*': 'lit' } -> * is not part of router??
 
-      request.hRequest = new Request(url, {
-        headers: request.headers,
-        method: request.method,
-        params: request.params,
-      });
-
-      request.hResponse = new Response();
-
-      // Handle HTTP POST: application/x-www-form-urlencoded
-      if (request.method === 'POST' || request.method === 'PUT') {
-        // Copy original body into a FormData object
-        Object.entries(request.body).forEach(([key, value]) => {
-          request.hRequest.body.append(key, value);
+        request.hRequest = new Request(url, {
+          headers: request.headers,
+          method: request.method,
+          params: request.params,
         });
-      }
 
-      // Set specific values for "actions"
-      if (request.routeOptions.config.entry.type === 'action') {
-        request.hResponse.location = request.hRequest.url;
-        request.hResponse.status = 303;
-        request.hResponse.type = 'text/plain; charset=utf-8';
-      }
+        request.hResponse = new Response();
 
-      // Set specific values for "routes"
-      if (request.routeOptions.config.entry.type === 'route') {
-        request.hResponse.type = 'application/json; charset=utf-8';
-      }
+        // Handle HTTP POST: application/x-www-form-urlencoded
+        if (request.method === 'POST' || request.method === 'PUT') {
+          // Copy original body into a FormData object
+          Object.entries(request.body).forEach(([key, value]) => {
+            request.hRequest.body.append(key, value);
+          });
+        }
 
-      try {
-        const props = await hook.middleware(request.hRequest, request.hResponse);
-        request.hResponse.context = props;
-      } catch (error) {
-        fastify.log.error(error);
-      }
-    });
+        // Set specific values for "actions"
+        if (request.routeOptions.config.entry.type === 'action') {
+          request.hResponse.location = request.hRequest.url;
+          request.hResponse.status = 303;
+          request.hResponse.type = 'text/plain; charset=utf-8';
+        }
+
+        // Set specific values for "routes"
+        if (request.routeOptions.config.entry.type === 'route') {
+          request.hResponse.type = 'application/json; charset=utf-8';
+        }
+
+        try {
+          const props = await hook.middleware(request.hRequest, request.hResponse);
+          request.hResponse.context = props;
+        } catch (error) {
+          fastify.log.error(error);
+        }
+      },
+    );
   },
   {
     fastify: '4',

--- a/lib/server/plugins/router/route-action.js
+++ b/lib/server/plugins/router/route-action.js
@@ -1,11 +1,20 @@
 import { mapFileSystemRoute } from './router-mapping.js';
 
+/**
+ * @typedef {import('../../../classes/request.js').default} HRequest
+ * @typedef {import('../../../classes/response.js').default} HResponse
+ * @typedef {import('../../../classes/header.js').default} HHeader
+ */
+
 // multipart/form-data
 // curl -L POST -i -F field=value http://localhost:4000/submit
 
 // application/x-www-form-urlencoded
 // curl -L POST -i -d field=value http://localhost:4000/submit
 
+/**
+ * @returns {Promise<import('fastify').RouteOptions>}
+ */
 export default async ({ entry, logger }) => {
   const source = await import(`${entry.source.href}`);
   const action = source.default;
@@ -21,7 +30,7 @@ export default async ({ entry, logger }) => {
       const middleware = await import(middlewareUri);
       hook = middleware;
       logger.trace(`Loaded external middleware for route ${entry.route}`);
-    } catch (error) { // eslint-disable-line
+    } catch {
       // Do nothing when middleware does not exist
     }
   }
@@ -36,6 +45,9 @@ export default async ({ entry, logger }) => {
     },
     //schema: { ... },
 
+    /**
+     * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+     */
     preHandler: async (request) => {
       if (hook?.middleware) {
         const res = request.hResponse;
@@ -46,6 +58,10 @@ export default async ({ entry, logger }) => {
       }
     },
 
+    /**
+     * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+     * @param {import('fastify').FastifyReply & { ssr?: (page: any) => import('@lit-labs/ssr/lib/render-result-readable.js').RenderResultReadable }} reply
+     */
     handler: async function (request, reply) {
       const res = request.hResponse;
       const req = request.hRequest;

--- a/lib/server/plugins/router/route-page.js
+++ b/lib/server/plugins/router/route-page.js
@@ -1,5 +1,14 @@
 import { mapFileSystemRoute } from './router-mapping.js';
 
+/**
+ * @typedef {import('../../../classes/request.js').default} HRequest
+ * @typedef {import('../../../classes/response.js').default} HResponse
+ * @typedef {import('../../../classes/header.js').default} HHeader
+ */
+
+/**
+ * @returns {Promise<import('fastify').RouteOptions>}
+ */
 export default async ({ config, entry, logger }) => {
   const source = await import(`${entry.source.href}`);
   const page = source.default;
@@ -15,7 +24,7 @@ export default async ({ config, entry, logger }) => {
       const middleware = await import(middlewareUri);
       hook = middleware;
       logger.trace(`Loaded external middleware for route ${entry.route}`);
-    } catch (error) { // eslint-disable-line
+    } catch {
       // Do nothing when middleware does not exist
     }
   }
@@ -30,32 +39,41 @@ export default async ({ config, entry, logger }) => {
     },
     //schema: { ... },
 
-    preHandler: async (request) => {
-      if (hook?.middleware) {
+    preHandler:
+      /**
+       * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+       */
+      async (request) => {
+        if (hook?.middleware) {
+          const res = request.hResponse;
+          const req = request.hRequest;
+
+          const context = await hook.middleware(req, res);
+          res.context = context;
+        }
+      },
+
+    handler:
+      /**
+       * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+       * @param {import('fastify').FastifyReply & { ssr?: (page: any) => import('@lit-labs/ssr/lib/render-result-readable.js').RenderResultReadable }} reply
+       */
+      async function (request, reply) {
         const res = request.hResponse;
-        const req = request.hRequest;
 
-        const context = await hook.middleware(req, res);
-        res.context = context;
-      }
-    },
+        // TODO: Build proper script tags
+        const scriptHydrationUrl = config.urlPathToJs('/lit/hydration.js');
+        request.header.setScript(scriptHydrationUrl.href);
 
-    handler: async function (request, reply) {
-      const res = request.hResponse;
+        const scriptPageUrl = config.urlPathToJs(`/pages/${request.routeOptions.config.entry.hash}.js`);
+        request.header.setScript(scriptPageUrl.href);
 
-      // TODO: Build proper script tags
-      const scriptHydrationUrl = config.urlPathToJs('/lit/hydration.js');
-      request.header.setScript(scriptHydrationUrl.href);
+        res.headers.forEach((value, key) => {
+          reply.header(key, value);
+        });
 
-      const scriptPageUrl = config.urlPathToJs(`/pages/${request.routeOptions.config.entry.hash}.js`);
-      request.header.setScript(scriptPageUrl.href);
-
-      res.headers.forEach((value, key) => {
-        reply.header(key, value);
-      });
-
-      reply.type(res.type);
-      return reply.ssr(page);
-    },
+        reply.type(res.type);
+        return reply.ssr(page);
+      },
   };
 };

--- a/lib/server/plugins/router/route-route.js
+++ b/lib/server/plugins/router/route-route.js
@@ -1,11 +1,20 @@
 import { mapFileSystemRoute } from './router-mapping.js';
 
+/**
+ * @typedef {import('../../../classes/request.js').default} HRequest
+ * @typedef {import('../../../classes/response.js').default} HResponse
+ * @typedef {import('../../../classes/header.js').default} HHeader
+ */
+
 // multipart/form-data
 // curl -L POST -i -F field=value http://localhost:4000/submit
 
 // application/x-www-form-urlencoded
 // curl -L POST -i -d field=value http://localhost:4000/submit
 
+/**
+ * @returns {Promise<import('fastify').RouteOptions[]>}
+ */
 export default async ({ entry, logger }) => {
   const source = await import(`${entry.source.href}`);
 
@@ -20,11 +29,12 @@ export default async ({ entry, logger }) => {
       const middleware = await import(middlewareUri);
       hook = middleware;
       logger.trace(`Loaded external middleware for route ${entry.route}`);
-    } catch (error) { // eslint-disable-line
+    } catch {
       // Do nothing when middleware does not exist
     }
   }
 
+  /** @type {import('fastify').RouteOptions[]} */
   const routes = [];
   const route = mapFileSystemRoute(entry.route);
 
@@ -38,6 +48,9 @@ export default async ({ entry, logger }) => {
       },
       //schema: { ... },
 
+      /**
+       * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+       */
       preHandler: async (request) => {
         if (hook?.middleware) {
           const res = request.hResponse;
@@ -48,6 +61,10 @@ export default async ({ entry, logger }) => {
         }
       },
 
+      /**
+       * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+       * @param {import('fastify').FastifyReply & { ssr?: (page: any) => import('@lit-labs/ssr/lib/render-result-readable.js').RenderResultReadable }} reply
+       */
       handler: async function (request, reply) {
         const res = request.hResponse;
         const req = request.hRequest;
@@ -75,30 +92,39 @@ export default async ({ entry, logger }) => {
       },
       //schema: { ... },
 
-      preHandler: async (request) => {
-        if (hook?.middleware) {
+      preHandler:
+        /**
+         * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+         */
+        async (request) => {
+          if (hook?.middleware) {
+            const res = request.hResponse;
+            const req = request.hRequest;
+
+            const context = await hook.middleware(req, res);
+            res.context = context;
+          }
+        },
+
+      handler:
+        /**
+         * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+         * @param {import('fastify').FastifyReply & { ssr?: (page: any) => import('@lit-labs/ssr/lib/render-result-readable.js').RenderResultReadable }} reply
+         */
+        async function (request, reply) {
           const res = request.hResponse;
           const req = request.hRequest;
 
-          const context = await hook.middleware(req, res);
-          res.context = context;
-        }
-      },
+          const body = await source.PUT(req, res);
 
-      handler: async function (request, reply) {
-        const res = request.hResponse;
-        const req = request.hRequest;
+          res.headers.forEach((value, key) => {
+            reply.header(key, value);
+          });
 
-        const body = await source.PUT(req, res);
+          reply.type(res.type);
 
-        res.headers.forEach((value, key) => {
-          reply.header(key, value);
-        });
-
-        reply.type(res.type);
-
-        return body;
-      },
+          return body;
+        },
     });
   }
 
@@ -112,30 +138,39 @@ export default async ({ entry, logger }) => {
       },
       //schema: { ... },
 
-      preHandler: async (request) => {
-        if (hook?.middleware) {
+      preHandler:
+        /**
+         * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+         */
+        async (request) => {
+          if (hook?.middleware) {
+            const res = request.hResponse;
+            const req = request.hRequest;
+
+            const context = await hook.middleware(req, res);
+            res.context = context;
+          }
+        },
+
+      handler:
+        /**
+         * @param {import('fastify').FastifyRequest & { hRequest: HRequest; hResponse: HResponse; header: HHeader; }} request
+         * @param {import('fastify').FastifyReply & { ssr?: (page: any) => import('@lit-labs/ssr/lib/render-result-readable.js').RenderResultReadable }} reply
+         */
+        async function (request, reply) {
           const res = request.hResponse;
           const req = request.hRequest;
 
-          const context = await hook.middleware(req, res);
-          res.context = context;
-        }
-      },
+          const body = await source.POST(req, res);
 
-      handler: async function (request, reply) {
-        const res = request.hResponse;
-        const req = request.hRequest;
+          res.headers.forEach((value, key) => {
+            reply.header(key, value);
+          });
 
-        const body = await source.POST(req, res);
+          reply.type(res.type);
 
-        res.headers.forEach((value, key) => {
-          reply.header(key, value);
-        });
-
-        reply.type(res.type);
-
-        return body;
-      },
+          return body;
+        },
     });
   }
 

--- a/lib/server/plugins/router/router.js
+++ b/lib/server/plugins/router/router.js
@@ -21,6 +21,7 @@ export default fp(
   async (fastify, { config, hierarchy } = {}) => {
     // TODO: Set default header here????
     fastify.addHook('preHandler', async (request) => {
+      // @ts-expect-error
       request.header = new Header();
     });
 
@@ -44,7 +45,7 @@ export default fp(
       // Set "action" route
       if (entry.type === 'action') {
         try {
-          const route = await routeAction({ config, entry, logger });
+          const route = await routeAction({ entry, logger });
           fastify.route(route);
         } catch (error) {
           fastify.log.warn(`Router could not import action at path ${entry.source.href}`);
@@ -55,7 +56,7 @@ export default fp(
       // Set "route" route
       if (entry.type === 'route') {
         try {
-          const routes = await routeRoute({ config, entry, logger });
+          const routes = await routeRoute({ entry, logger });
           routes.forEach((route) => {
             fastify.route(route);
           });

--- a/lib/server/server-dev.js
+++ b/lib/server/server-dev.js
@@ -27,6 +27,7 @@ export default class ServerDevelopment {
 
     this.#config = config;
 
+    // @ts-expect-error
     this.#logger = pino({
       level: this.#config.logLevel,
       name: this.#config.logName,

--- a/lib/server/server-prod.js
+++ b/lib/server/server-prod.js
@@ -25,6 +25,7 @@ export default class ServerProduction {
 
     this.#config = config;
 
+    // @ts-expect-error
     this.#logger = pino({
       level: this.#config.logLevel,
       name: this.#config.logName,

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "lit": "3.2.0",
     "npm-run-all2": "6.2.2",
     "prettier": "3.3.3",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
     "semantic-release": "24.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,22 @@
     "lib"
   ],
   "exports": {
-    "./response": "./lib/classes/response.js",
-    "./request": "./lib/classes/request.js",
-    "./server": "./lib/main.js",
-    "./test": "./lib/test/test.js"
+    "./response": {
+      "types": "./types/classes/response.d.ts",
+      "default": "./lib/classes/response.js"
+    },
+    "./request": {
+      "types": "./types/classes/request.d.ts",
+      "default": "./lib/classes/request.js"
+    },
+    "./server": {
+      "types": "./types/main.d.ts",
+      "default": "./lib/main.js"
+    },
+    "./test": {
+      "types": "./types/test/test.d.ts",
+      "default": "./lib/test/test.js"
+    }
   },
   "imports": {
     "#components/*": "./components/*",
@@ -32,7 +44,12 @@
     "dev": "node ./bin/dev.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "test": "node --test"
+    "test": "node --test",
+    "types": "run-s types:module types:fixup types:test",
+    "types:module": "tsc",
+    "types:fixup": "node fixup.js",
+    "types:test": "tsc --project tsconfig.test.json",
+    "prepublishOnly": "npm run types"
   },
   "author": "Trygve Lie",
   "license": "MIT",
@@ -43,8 +60,8 @@
     "@fastify/etag": "5.2.0",
     "@fastify/formbody": "7.4.0",
     "@fastify/static": "7.0.4",
-    "@lit-labs/ssr-client": "1.1.7",
     "@lit-labs/ssr": "3.2.2",
+    "@lit-labs/ssr-client": "1.1.7",
     "abslog": "2.4.4",
     "commander": "12.1.0",
     "dotenv": "16.4.5",
@@ -62,22 +79,25 @@
     "@rollup/plugin-replace": "5.0.7",
     "@rollup/plugin-terser": "0.4.4",
     "@rollup/plugin-typescript": "11.1.6",
+    "chokidar": "3.6.0",
     "esbuild": "0.23.0",
     "esbuild-plugin-import-map": "3.0.0-next.2",
-    "rollup": "4.20.0",
     "get-port": "7.1.0",
-    "chokidar": "3.6.0"
+    "rollup": "4.20.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
+    "@types/node": "22.4.0",
     "eslint": "9.9.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
     "globals": "15.9.0",
     "lit": "3.2.0",
+    "npm-run-all2": "6.2.2",
     "prettier": "3.3.3",
-    "semantic-release": "24.0.0"
+    "semantic-release": "24.0.0",
+    "typescript": "5.5.4"
   },
   "engines": {
     "node": ">=22"

--- a/test/classes/response.js
+++ b/test/classes/response.js
@@ -51,6 +51,7 @@ test('Response - .headers', async (t) => {
   await t.test('Illegal value', () => {
     const response = new HResponse();
     try {
+      // @ts-expect-error Testing bad input
       response.headers = 'foo:bar';
     } catch (err) {
       assert.match(err.message, /Value must be of type Headers/, 'Should throw');
@@ -97,6 +98,7 @@ test('Response - .status', async (t) => {
   await t.test('Illegal value', () => {
     const response = new HResponse();
     try {
+      // @ts-expect-error Testing bad input
       response.status = '204';
     } catch (err) {
       assert.match(err.message, /Value must be a integer/, 'Should throw');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["./lib/**/*.js"],
   "compilerOptions": {
-    "rootDir": ".",
     "lib": ["es2020", "DOM"],
     "module": "nodenext",
     "moduleResolution": "nodenext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,18 @@
 {
-	"compilerOptions": {
-		"lib": ["es2020", "DOM"],
-		"module": "nodenext",
-		"target": "es2020",
-		"resolveJsonModule": true,
-		"checkJs": true,
-		"allowJs": true,
-		"moduleResolution": "nodenext",
-		"declaration": true,
-		"skipLibCheck": true,
-		"allowSyntheticDefaultImports": true,
-		"outDir": "types"
-	}
+  "include": ["./lib/**/*.js"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "lib": ["es2020", "DOM"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2020",
+    "resolveJsonModule": true,
+    "checkJs": true,
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "types"
+  }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./lib/**/*.js", "./test/**/*.js"],
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true
+  }
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": ["./lib/**/*.js", "./test/**/*.js"],
   "compilerOptions": {
+    "rootDir": ".",
     "emitDeclarationOnly": false,
     "noEmit": true
   }


### PR DESCRIPTION
It seemed from `"files"` and `tsconfig.json` we wanted to include type definitions. This adds a setup similar to the one used in podium-lib. `hubro.d.ts` and `fixup.js` lets us extend for instance the FastifyReply and FastifyRequest interfaces should we need to.