### PR TITLE
feat: Export lit-labs/ssr as hubro/ssr

### DIFF
--- a/docs/4-routing.md
+++ b/docs/4-routing.md
@@ -21,7 +21,7 @@ Pages must include a function as its default export. That function must return
 a Lit `TemplateResult` (typically [html](https://lit.dev/docs/api/static-html/#html)).
 
 ```js
-import { html } from 'lit';
+import { html } from 'hubro/ssr';
 
 export default () => {
   return html`
@@ -62,7 +62,7 @@ Let's make a form that submits your favorite `bird` to an action. We'll be worki
 In `pages/page.js` we add a form that `POST`s an `input` with the name `bird` to the action `/submit`.
 
 ```js
-import { html } from 'lit';
+import { html } from 'hubro/ssr';
 
 export default () => {
   return html`

--- a/lib/modules/ssr/ssr.js
+++ b/lib/modules/ssr/ssr.js
@@ -1,0 +1,1 @@
+export * from '@lit-labs/ssr';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.1",
   "type": "module",
   "description": "",
-  "types": "types/main.d.ts",
   "bin": {
     "hubro": "./bin/bin.js"
   },
@@ -33,6 +32,9 @@
     "./test": {
       "types": "./types/test/test.d.ts",
       "default": "./lib/test/test.js"
+    },
+    "./ssr": {
+      "default": "./lib/modules/ssr/ssr.js"
     }
   },
   "imports": {


### PR DESCRIPTION
Re-exporting the @lit-labs/ssr module so it can be used like so in server side templates:

```js
import { html } from 'hubro/ssr';
```